### PR TITLE
NA values should be coded as 0 instead of NA in dichotom()

### DIFF
--- a/R/dichotom.R
+++ b/R/dichotom.R
@@ -5,7 +5,10 @@ dichotom <- function(data,out='numeric') {
     if(is.factor(data[,i])==FALSE) data[,i] <- factor(data[,i])
     nlevels <- length(levels(data[,i]))
     temp <- matrix(nrow=nrow(data),ncol=nlevels)
-    for(j in 1:nlevels) temp[,j] <- ifelse(data[,i]==levels(data[,i])[j],1,0)
+    for(j in 1:nlevels) {
+      temp[,j] <- 0
+      temp[data[,i]==levels(data[,i])[j] ,j] <- 1
+    }
     colnames(temp) <- paste(names(data)[i],levels(data[,i]),sep=".")
     if(i==1) res <- temp else res <- cbind(res,temp)
     }


### PR DESCRIPTION
Hi,

And first of all, many thanks for your work on `GDAtools`, which is a very useful package.

When using `varsup` with a factor containing missing values, sometimes the computed coordinates are all `NA` : 

``` r
library(GDAtools)
library(questionr)
data(hdv2003)
acm <- speMCA(hdv2003[, c("sexe", "relig", "occup", "hard.rock")])
sup <- GDAtools::varsup(acm, hdv2003$qualif)
sup$coord
#>                          dim.1 dim.2 dim.3 dim.4 dim.5
#> Ouvrier specialise          NA    NA    NA    NA    NA
#> Ouvrier qualifie            NA    NA    NA    NA    NA
#> Technicien                  NA    NA    NA    NA    NA
#> Profession intermediaire    NA    NA    NA    NA    NA
#> Cadre                       NA    NA    NA    NA    NA
#> Employe                     NA    NA    NA    NA    NA
#> Autre                       NA    NA    NA    NA    NA
```

It seems that the problem comes from the `dichotom` function : the test used to compute the results puts an `NA` value in all the levels instead of `0` when the dichotomised variable value is `NA`.

This PR aims to fix this problem by outputting `0` for `NA` values. After this fix is applied the computed supplementary variable coordinates in the above example are the same as the ones computed, for example, by `FactoMineR::MCA`.